### PR TITLE
fix yearly timeframe for dashboard

### DIFF
--- a/ui/src/hooks/useStats.ts
+++ b/ui/src/hooks/useStats.ts
@@ -13,9 +13,10 @@ function calculateMonthlyRange() {
 }
 
 function calculateYearlyRange() {
-  const upper = format(new Date(), 'yyyy-MM-dd');
-  const lower = format(subMonths(new Date(), 12), 'yyyy-MM-dd');
-
+  const today = new Date();
+  const upper = format(today, 'yyyy-MM-dd');
+  const currentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const lower = format(subMonths(currentMonth, 11), 'yyyy-MM-dd');
   return { upper, lower };
 }
 


### PR DESCRIPTION
modify calculateYearlyRange function to get the current month, and previous 11 months, for formatting 12 months on dashboard charts