### PR TITLE
pyth matic id changed

### DIFF
--- a/ui/src/utils/pyth.tsx
+++ b/ui/src/utils/pyth.tsx
@@ -40,6 +40,7 @@ export const getMarketsPythConfig = async () => {
     .then((json) => {
       const parsedJson = OffchainFeedSchema.parse(json);
       return parsedJson
+        .filter(({ asset }) => asset !== 'MATIC')
         .map(({ feedId, asset }) => {
           const key = formatAssetToPerpName(asset);
           return {


### PR DESCRIPTION
pyth asset id changed for matic. this pr filters out matic to keep site operational, while i work on update for name/asset id change.